### PR TITLE
Consider expanded flag in plasmoid status

### DIFF
--- a/package/contents/code/data-loader.js
+++ b/package/contents/code/data-loader.js
@@ -51,11 +51,15 @@ function getReloadedAgoMs(lastReloaded) {
 }
 
 function getPlasmoidStatus(lastReloaded, inTrayActiveTimeoutSec) {
-    var reloadedAgoMs = getReloadedAgoMs(lastReloaded)
-    if (reloadedAgoMs < inTrayActiveTimeoutSec*1000) {
-        return PlasmaCore.Types.ActiveStatus
+    if (plasmoid.expanded) {
+        return PlasmaCore.Types.NeedsAttentionStatus
     } else {
-        return PlasmaCore.Types.PassiveStatus
+        var reloadedAgoMs = getReloadedAgoMs(lastReloaded)
+        if (reloadedAgoMs < inTrayActiveTimeoutSec*1000) {
+            return PlasmaCore.Types.ActiveStatus
+        } else {
+            return PlasmaCore.Types.PassiveStatus
+        }
     }
 }
 


### PR DESCRIPTION
--when an applet is expanded and shows its popup
then plasma by default sets that applet to
NeedsAttention status. This is considered when
the plasmoid status needs to be updated.
--this commit fixes also a Latte issue when Latte
was hiding even though the weather popup is shown.
Latte is checking the plasmoid status in order to
identify if needs to block its automatic hiding.
https://bugs.kde.org/show_bug.cgi?id=391818